### PR TITLE
Output entityTypes for signals.

### DIFF
--- a/exabel/api/data/doc/signals.rst
+++ b/exabel/api/data/doc/signals.rst
@@ -45,12 +45,14 @@ Retrieves the signal catalogue.
           "name": "signals/customer1.customer_amount",
           "displayName": "Amount per customer",
           "description": "The amount spent per customer in a store per day",
-          "downsamplingMethod": "MEAN"
+          "downsamplingMethod": "MEAN",
+          "entityTypes": ["entityTypes/customer1.stores"],
         },
         {
           "name": "signals/customer1.visitors",
           "displayName": "Daily visitors",
           "description": "The number of visitors in a store per day",
+          "entityTypes": ["entityTypes/customer1.stores"],
           "downsamplingMethod": "SUM"
         }
       ],
@@ -70,6 +72,7 @@ Get signal
     :resjson string downsamplingMethod: The default downsampling method to use when this signal is re-sampled into
         larger intervals. When two or more values in an interval needs to be aggregated into a single value, specifies
         how they are combined. One of ``MEAN``, ``FIRST``, ``LAST``, ``SUM``, ``MIN``, ``MAX``.
+    :resjson array entityTypes: Resource names of the types of entities this signal has time series for.
 
 ..  http:example:: curl wget python-requests
 
@@ -86,7 +89,8 @@ Get signal
       "name": "signals/customer1.visitors",
       "displayName": "Daily visitors",
       "description": "The number of visitors in a store per day",
-      "downsamplingMethod": "SUM"
+      "downsamplingMethod": "SUM",
+      "entityTypes": ["entityTypes/customer1.stores"],
     }
 
 
@@ -176,6 +180,7 @@ Update signal
       "name": "signals/customer1.visitors",
       "displayName": "Daily visitors",
       "description": "The number of visitors in a store per day"
+      "entityTypes": ["entityTypes/customer1.stores"],
     }
 
 

--- a/exabel/api/data/pom.xml
+++ b/exabel/api/data/pom.xml
@@ -9,7 +9,7 @@
     <relativePath>../../..</relativePath>
   </parent>
   <artifactId>data</artifactId>
-  <version>1.0.10</version>
+  <version>1.0.11</version>
 
   <dependencies>
     <dependency>

--- a/exabel/api/data/v1/signal_messages.proto
+++ b/exabel/api/data/v1/signal_messages.proto
@@ -30,4 +30,7 @@ message Signal {
   api.math.Aggregation downsampling_method = 5;
   // Output only. Whether this resource is read only.
   bool read_only = 6;
+  // Output only. The types of entities that this signal has time series for, for example
+  // "entityTypes/ns.type1", "entityTypes/ns.type2".
+  repeated string entity_types = 7;
 }


### PR DESCRIPTION
CC @burk @hallarak

The relationship between signal and entity type will be created in `CreateTimeSeries` instead of `CreateSignal` as previously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exabel/api/42)
<!-- Reviewable:end -->
